### PR TITLE
Fix SMAA heap property initialization

### DIFF
--- a/OptiScaler/shaders/smaa/SMAA_Dx12.cpp
+++ b/OptiScaler/shaders/smaa/SMAA_Dx12.cpp
@@ -184,7 +184,7 @@ bool SMAA_Dx12::EnsureTextures(ID3D12Resource* inputColor)
     auto desc = inputColor->GetDesc();
 
     CD3DX12_HEAP_PROPERTIES defaultHeapProperties(D3D12_HEAP_TYPE_DEFAULT);
-    CD3DX12_HEAP_PROPERTIES heapProperties(defaultHeapProperties);
+    D3D12_HEAP_PROPERTIES heapProperties = defaultHeapProperties;
     D3D12_HEAP_FLAGS heapFlags = D3D12_HEAP_FLAG_NONE;
     HRESULT hr = S_OK;
 


### PR DESCRIPTION
## Summary
- initialize the SMAA fallback heap properties with a plain D3D12 descriptor so assigning input heap properties compiles cleanly

## Testing
- dotnet build OptiScaler.sln *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cac37eb6348322a08cedc6c3d4fb9e