### PR TITLE
Add DLSS input debug preview for SMAA

### DIFF
--- a/Config.md
+++ b/Config.md
@@ -142,6 +142,10 @@ ColorSpaceConversion=auto
 ; Enables SMAA anti-aliasing before the selected upscaler
 ; true or false - Default (auto) is false
 Enabled=auto
+
+; Shows the SMAA processed color buffer that is sent to DLSS (DirectX 12)
+; true or false - Default (auto) is false
+DebugShowDlssInput=auto
 ```
 
 The `BuildPipelines` parameter allows XeSS pipelines to be built during context creation to prevent stuttering later.
@@ -168,6 +172,8 @@ It can be changed from the in-game menu with real-time results.
 When enabled, OptiScaler executes a lightweight SMAA pass on the color buffer before handing it to the selected upscaler.
 This helps smooth jagged edges in games that do not offer post-processing anti-aliasing without changing the chosen upscale
 r or its quality settings. The option can also be toggled from the in-game menu.
+
+With `DebugShowDlssInput` you can preview the SMAA processed texture that DLSS receives. The preview appears in the DirectX 12 menu when the toggle is enabled, making it easier to verify that the input buffer looks as expected while tuning SMAA settings.
 
 ### FSR Settings
 

--- a/OptiScaler.ini
+++ b/OptiScaler.ini
@@ -423,6 +423,10 @@ RenderPresetUltraPerformance=auto
 ; true or false - Default (auto) is false
 UseGenericAppIdWithDlss=auto
 
+; Show the SMAA processed DLSS input in the menu (DirectX 12)
+; true or false - Default (auto) is false
+DebugShowDlssInput=auto
+
 
 
 ; -------------------------------------------------------

--- a/OptiScaler/Config.cpp
+++ b/OptiScaler/Config.cpp
@@ -164,6 +164,7 @@ bool Config::Reload(std::filesystem::path iniPath)
             DLSSFeaturePath.set_from_config(readWString("DLSS", "FeaturePath"));
             NVNGX_DLSS_Library.set_from_config(readWString("DLSS", "NVNGX_DLSS_Path"));
             UseGenericAppIdWithDlss.set_from_config(readBool("DLSS", "UseGenericAppIdWithDlss"));
+            DebugShowDlssInput.set_from_config(readBool("DLSS", "DebugShowDlssInput"));
 
             RenderPresetOverride.set_from_config(readBool("DLSS", "RenderPresetOverride"));
 
@@ -784,6 +785,8 @@ bool Config::SaveIni()
                      GetIntValue(Instance()->RenderPresetUltraPerformance.value_for_config()).c_str());
         ini.SetValue("DLSS", "UseGenericAppIdWithDlss",
                      GetBoolValue(Instance()->UseGenericAppIdWithDlss.value_for_config()).c_str());
+        ini.SetValue("DLSS", "DebugShowDlssInput",
+                     GetBoolValue(Instance()->DebugShowDlssInput.value_for_config()).c_str());
     }
 
     // Nukems

--- a/OptiScaler/Config.h
+++ b/OptiScaler/Config.h
@@ -206,6 +206,7 @@ class Config
 
     // SMAA
     CustomOptional<bool> SmaaEnabled { false };
+    CustomOptional<bool> DebugShowDlssInput { false };
 
     // Sharpness
     CustomOptional<bool> OverrideSharpness { false };

--- a/OptiScaler/menu/menu_common.cpp
+++ b/OptiScaler/menu/menu_common.cpp
@@ -3397,6 +3397,34 @@ bool MenuCommon::RenderMenu()
                             Config::Instance()->SmaaEnabled = smaa;
                         ShowHelpMarker("Applies a SMAA antialiasing pass before the upscaler.");
 
+                        if (State::Instance().api == DX12)
+                        {
+                            if (bool showDebug = Config::Instance()->DebugShowDlssInput.value_or_default();
+                                ImGui::Checkbox("Show DLSS Input", &showDebug))
+                                Config::Instance()->DebugShowDlssInput = showDebug;
+                            ShowHelpMarker("Displays the SMAA-processed color buffer that DLSS receives.");
+
+                            if (Config::Instance()->DebugShowDlssInput.value_or_default())
+                            {
+                                auto previewTexture = DlssInputPreviewTexture();
+                                auto previewSize = DlssInputPreviewSize();
+
+                                if (previewTexture != ImTextureID_Invalid && previewSize.x > 0.0f && previewSize.y > 0.0f)
+                                {
+                                    float maxWidth = 320.0f * Config::Instance()->MenuScale.value_or_default();
+                                    float aspect = previewSize.y / previewSize.x;
+                                    if (aspect <= 0.0f)
+                                        aspect = 1.0f;
+                                    ImVec2 imageSize { maxWidth, maxWidth * aspect };
+                                    ImGui::Image(ImTextureRef(previewTexture), imageSize);
+                                }
+                                else
+                                {
+                                    ImGui::TextDisabled("Preview unavailable.");
+                                }
+                            }
+                        }
+
                         ImGui::Spacing();
 
                         // xess or dlss version >= 2.5.1

--- a/OptiScaler/menu/menu_common.h
+++ b/OptiScaler/menu/menu_common.h
@@ -72,6 +72,9 @@ class MenuCommon
     inline static bool _dx12Ready = false;
     inline static bool _vulkanReady = false;
 
+    inline static ImTextureID _dlssInputPreviewTexture = ImTextureID_Invalid;
+    inline static ImVec2 _dlssInputPreviewSize { 0.0f, 0.0f };
+
     inline static void ShowTooltip(const char* tip);
 
     inline static void ShowHelpMarker(const char* tip);
@@ -153,4 +156,13 @@ class MenuCommon
     static void Init(HWND InHwnd, bool isUWP);
     static void Shutdown();
     static void HideMenu();
+
+    static void SetDlssInputPreview(ImTextureID textureId, ImVec2 size)
+    {
+        _dlssInputPreviewTexture = textureId;
+        _dlssInputPreviewSize = size;
+    }
+
+    static ImTextureID DlssInputPreviewTexture() { return _dlssInputPreviewTexture; }
+    static ImVec2 DlssInputPreviewSize() { return _dlssInputPreviewSize; }
 };

--- a/OptiScaler/menu/menu_dx12.h
+++ b/OptiScaler/menu/menu_dx12.h
@@ -15,10 +15,15 @@ class Menu_Dx12 : public MenuDxBase
     ID3D12DescriptorHeap* _srvDescHeap = nullptr;
     D3D12_CPU_DESCRIPTOR_HANDLE _renderTargetDescriptor[2] = {};
 
+    bool _dlssPreviewDescriptorAllocated = false;
+    D3D12_CPU_DESCRIPTOR_HANDLE _dlssPreviewSrvCpu {};
+    D3D12_GPU_DESCRIPTOR_HANDLE _dlssPreviewSrvGpu {};
+
     void CreateRenderTarget(const D3D12_RESOURCE_DESC& InDesc);
 
   public:
     bool Render(ID3D12GraphicsCommandList* pCmdList, ID3D12Resource* outTexture);
+    void UpdateDlssInputPreview(ID3D12Resource* resource);
 
     Menu_Dx12(HWND handle, ID3D12Device* pDevice);
 

--- a/OptiScaler/upscalers/dlss/DLSSFeature_Dx12.h
+++ b/OptiScaler/upscalers/dlss/DLSSFeature_Dx12.h
@@ -7,6 +7,11 @@
 class DLSSFeatureDx12 : public DLSSFeature, public IFeature_Dx12
 {
   private:
+    ID3D12Resource* _dlssDebugTexture = nullptr;
+    D3D12_RESOURCE_STATES _dlssDebugState = D3D12_RESOURCE_STATE_COMMON;
+
+    bool EnsureDebugTexture(ID3D12Resource* source);
+    void CopyDebugTexture(ID3D12GraphicsCommandList* commandList, ID3D12Resource* source);
   protected:
   public:
     bool Init(ID3D12Device* InDevice, ID3D12GraphicsCommandList* InCommandList,


### PR DESCRIPTION
## Summary
- add a DebugShowDlssInput option to the configuration and in-game menu
- capture the SMAA processed resource in the DX12 DLSS path and expose it to the menu overlay
- document how to enable the new DLSS input preview

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cac7b743248322b28b3796d2c3d461