### PR TITLE
Handle SMAA UAV format fallback for non-float swapchains

### DIFF
--- a/OptiScaler/shaders/smaa/SMAA_Dx12.h
+++ b/OptiScaler/shaders/smaa/SMAA_Dx12.h
@@ -40,6 +40,8 @@ class SMAA_Dx12
     ID3D12Resource* _blendTexture = nullptr;
     ID3D12Resource* _outputTexture = nullptr;
 
+    DXGI_FORMAT _outputTextureFormat = DXGI_FORMAT_UNKNOWN;
+
     D3D12_RESOURCE_STATES _edgeState = D3D12_RESOURCE_STATE_COMMON;
     D3D12_RESOURCE_STATES _blendState = D3D12_RESOURCE_STATE_COMMON;
     D3D12_RESOURCE_STATES _outputState = D3D12_RESOURCE_STATE_COMMON;
@@ -64,6 +66,7 @@ class SMAA_Dx12
     bool Dispatch(ID3D12GraphicsCommandList* commandList, ID3D12Resource* colorResource);
 
     ID3D12Resource* ProcessedResource() const { return _outputTexture; }
+    DXGI_FORMAT OutputTextureFormat() const { return _outputTextureFormat; }
 
     ~SMAA_Dx12();
 };


### PR DESCRIPTION
## Summary
- detect when the resolved swap chain format cannot be used for UAV typed stores and fall back to a float format when needed
- track the chosen UAV format so descriptor creation uses the float-compatible format for the SMAA output texture
- mirror the typed UAV store check and fallback on the Direct3D 11 path to restore SMAA support on 10-bit surfaces

## Testing
- not run (not supported in container)


------
https://chatgpt.com/codex/tasks/task_e_68cbf7ed24b08322a50424a93fdfc773