### PR TITLE
Ensure DLSS input preview works with overlay menu

### DIFF
--- a/OptiScaler/menu/menu_dx12.h
+++ b/OptiScaler/menu/menu_dx12.h
@@ -19,6 +19,7 @@ class Menu_Dx12 : public MenuDxBase
     D3D12_CPU_DESCRIPTOR_HANDLE _dlssPreviewSrvCpu {};
     D3D12_GPU_DESCRIPTOR_HANDLE _dlssPreviewSrvGpu {};
 
+    bool EnsurePreviewDescriptors();
     void CreateRenderTarget(const D3D12_RESOURCE_DESC& InDesc);
 
   public:

--- a/OptiScaler/upscalers/dlss/DLSSFeature_Dx12.cpp
+++ b/OptiScaler/upscalers/dlss/DLSSFeature_Dx12.cpp
@@ -170,7 +170,10 @@ bool DLSSFeatureDx12::Init(ID3D12Device* InDevice, ID3D12GraphicsCommandList* In
         RCAS = std::make_unique<RCAS_Dx12>("RCAS", InDevice);
         SMAA = std::make_unique<SMAA_Dx12>("SMAA", InDevice);
 
-        if (!Config::Instance()->OverlayMenu.value_or_default() && (Imgui == nullptr || Imgui.get() == nullptr))
+        bool overlayMenuEnabled = Config::Instance()->OverlayMenu.value_or_default();
+        bool debugPreviewEnabled = Config::Instance()->DebugShowDlssInput.value_or_default();
+
+        if (((!overlayMenuEnabled) || debugPreviewEnabled) && (Imgui == nullptr || Imgui.get() == nullptr))
             Imgui = std::make_unique<Menu_Dx12>(Util::GetProcessWindow(), InDevice);
 
         OutputScaler = std::make_unique<OS_Dx12>("OutputScaling", InDevice, (TargetWidth() < DisplayWidth()));
@@ -271,6 +274,10 @@ bool DLSSFeatureDx12::Evaluate(ID3D12GraphicsCommandList* InCommandList, NVSDK_N
         }
 
         bool debugPreviewRequested = Config::Instance()->DebugShowDlssInput.value_or_default();
+
+        if (debugPreviewRequested && Device != nullptr && (Imgui == nullptr || Imgui.get() == nullptr))
+            Imgui = std::make_unique<Menu_Dx12>(Util::GetProcessWindow(), Device);
+
         if (debugPreviewRequested && smaaApplied)
         {
             if (EnsureDebugTexture(SMAA->ProcessedResource()))


### PR DESCRIPTION
## Summary
- ensure the DX12 menu creates preview descriptor heaps even when the overlay menu is enabled
- instantiate or reuse the DX12 menu helper whenever the DLSS input preview is requested so the SMAA output can be shown
- guard descriptor allocation and cleanup so DLSS preview resources are released correctly on shutdown

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cc183c2d788322a16afffaec461ef7