### PR TITLE
Align DLSS preview descriptors with overlay heaps

### DIFF
--- a/OptiScaler/menu/menu_dx12.h
+++ b/OptiScaler/menu/menu_dx12.h
@@ -3,6 +3,8 @@
 #include "menu_dx_base.h"
 #include <d3d12.h>
 
+struct DescriptorHeapAllocator;
+
 class Menu_Dx12 : public MenuDxBase
 {
   private:
@@ -18,6 +20,7 @@ class Menu_Dx12 : public MenuDxBase
     bool _dlssPreviewDescriptorAllocated = false;
     D3D12_CPU_DESCRIPTOR_HANDLE _dlssPreviewSrvCpu {};
     D3D12_GPU_DESCRIPTOR_HANDLE _dlssPreviewSrvGpu {};
+    DescriptorHeapAllocator* _dlssPreviewAllocator = nullptr;
 
     bool EnsurePreviewDescriptors();
     void CreateRenderTarget(const D3D12_RESOURCE_DESC& InDesc);

--- a/OptiScaler/menu/menu_overlay_dx.cpp
+++ b/OptiScaler/menu/menu_overlay_dx.cpp
@@ -645,3 +645,13 @@ void MenuOverlayDx::Present(IDXGISwapChain* pSwapChain, UINT SyncInterval, UINT 
     if (device12 != nullptr)
         device12->Release();
 }
+
+ID3D12DescriptorHeap* MenuOverlayDx::SrvDescriptorHeap() { return g_pd3dSrvDescHeap; }
+
+DescriptorHeapAllocator* MenuOverlayDx::SrvDescriptorAllocator()
+{
+    if (g_pd3dSrvDescHeapAlloc.Heap == nullptr || g_pd3dSrvDescHeap == nullptr)
+        return nullptr;
+
+    return &g_pd3dSrvDescHeapAlloc;
+}

--- a/OptiScaler/menu/menu_overlay_dx.h
+++ b/OptiScaler/menu/menu_overlay_dx.h
@@ -4,6 +4,7 @@
 #include <d3d11_4.h>
 #include <d3d12.h>
 #include <dxgi1_6.h>
+#include <imgui/imgui_impl_dx12.h>
 
 namespace MenuOverlayDx
 {
@@ -11,4 +12,6 @@ ID3D12GraphicsCommandList* MenuCommandList();
 void CleanupRenderTarget(bool clearQueue, HWND hWnd);
 void Present(IDXGISwapChain* pSwapChain, UINT SyncInterval, UINT Flags,
              const DXGI_PRESENT_PARAMETERS* pPresentParameters, IUnknown* pDevice, HWND hWnd, bool isUWP);
+ID3D12DescriptorHeap* SrvDescriptorHeap();
+DescriptorHeapAllocator* SrvDescriptorAllocator();
 } // namespace MenuOverlayDx


### PR DESCRIPTION
## Summary
- detect overlay mode in the DX12 menu and source DLSS preview SRVs from the overlay descriptor heap when available
- expose descriptor heap/allocator accessors from the overlay renderer for reuse in the menu path
- return preview descriptors to the correct allocator during cleanup

## Testing
- not run (overlay preview requires a runtime environment)


------
https://chatgpt.com/codex/tasks/task_e_68cc21215e68832294ff4f49246827be