### PR TITLE
Adjust SMAA constants for shared factor

### DIFF
--- a/OptiScaler/shaders/smaa/SMAA_Dx11.h
+++ b/OptiScaler/shaders/smaa/SMAA_Dx11.h
@@ -12,8 +12,7 @@ class SMAA_Dx11
         float invResolution[2];
         float padding0[2];
         float threshold;
-        float edgeIntensity;
-        float blendStrength;
+        float sharedFactor;
         float padding1[2];
     };
 

--- a/OptiScaler/shaders/smaa/SMAA_Dx12.h
+++ b/OptiScaler/shaders/smaa/SMAA_Dx12.h
@@ -13,8 +13,7 @@ class SMAA_Dx12
         float invResolution[2];
         float padding0[2];
         float threshold;
-        float edgeIntensity;
-        float blendStrength;
+        float sharedFactor;
         float padding1[2];
     };
 
@@ -54,7 +53,7 @@ class SMAA_Dx12
     bool EnsureTextures(ID3D12Resource* inputColor);
     void TransitionResource(ID3D12GraphicsCommandList* commandList, ID3D12Resource* resource,
                              D3D12_RESOURCE_STATES& currentState, D3D12_RESOURCE_STATES targetState);
-    void UpdateConstants(ID3D12GraphicsCommandList* commandList, UINT width, UINT height);
+    void UpdateConstants(ID3D12GraphicsCommandList* commandList, UINT width, UINT height, float sharedFactor);
     void PopulateDescriptors(ID3D12Device* device, ID3D12Resource* colorResource);
 
   public:


### PR DESCRIPTION
## Summary
- collapse the SMAA constant buffer edge/blend values into a shared factor slot in both D3D11 and D3D12 implementations
- update the D3D11 dispatch to upload edge intensity before the edge pass and remap with blend strength for later passes
- refactor the D3D12 constant update helper so each pass binds the appropriate shared factor prior to dispatch

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc5fd319a48322a0419fbe6b43115c