### PR TITLE
Add SMAA Dx12 shader to project configuration

### DIFF
--- a/OptiScaler/OptiScaler.vcxproj
+++ b/OptiScaler/OptiScaler.vcxproj
@@ -558,6 +558,7 @@ copy NUL "$(SolutionDir)x64\Release\a\!! EXTRACT ALL FILES TO GAME FOLDER !!" /Y
     <ClCompile Include="shaders\rcas\RCAS_Dx11.cpp" />
     <ClCompile Include="shaders\rcas\RCAS_Dx12.cpp" />
     <ClCompile Include="shaders\smaa\CMAA2_Dx11.cpp" />
+    <ClCompile Include="shaders\smaa\SMAA_Dx12.cpp" />
     <ClCompile Include="upscalers\xess\XeSSFeature_Vk.cpp" />
     <ClCompile Include="Util.cpp" />
     <ClCompile Include="inputs\XeSS_Debug.cpp" />

--- a/OptiScaler/OptiScaler.vcxproj.filters
+++ b/OptiScaler/OptiScaler.vcxproj.filters
@@ -689,6 +689,9 @@
     <ClCompile Include="shaders\smaa\CMAA2_Dx11.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="shaders\smaa\SMAA_Dx12.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="include\imgui\imgui.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
## Summary
- include the SMAA DirectX 12 shader source in the project build configuration
- map the new shader source to the Source Files filter for proper Solution Explorer visibility

## Testing
- unable to run `msbuild OptiScaler.sln /t:Rebuild /p:Configuration=Release` due to missing msbuild in environment

------
https://chatgpt.com/codex/tasks/task_e_68cd75bd6e008322819bc38f4cef3377