### PR TITLE
Add placeholder resource tracking for SMAA DX12

### DIFF
--- a/OptiScaler/shaders/smaa/SMAA_Dx12.cpp
+++ b/OptiScaler/shaders/smaa/SMAA_Dx12.cpp
@@ -2,9 +2,25 @@
 
 #include <Logger.h>
 
+#include <d3d12.h>
+
+namespace
+{
+    void ResetHandles(SMAAResourceHandles& handles)
+    {
+        handles.cpu.ptr = 0;
+        handles.gpu.ptr = 0;
+    }
+}
+
 SMAA_Dx12::SMAA_Dx12(const char* name, ID3D12Device* device)
     : _name(name ? name : "SMAA"), _device(device)
 {
+    ResetHandles(_inputColorSrv);
+    ResetHandles(_edgeBufferUav);
+    ResetHandles(_blendBufferUav);
+    ResetHandles(_processedColorSrv);
+
     if (_device == nullptr)
     {
         LOG_WARN("[{}] SMAA DirectX 12 device is null - SMAA will be disabled", _name);
@@ -12,18 +28,116 @@ SMAA_Dx12::SMAA_Dx12(const char* name, ID3D12Device* device)
     }
     else
     {
-        LOG_WARN("[{}] SMAA DirectX 12 path is not implemented yet", _name);
-        _init = false;
+        LOG_INFO("[{}] SMAA DirectX 12 path is using a placeholder implementation", _name);
+        _init = true;
     }
 }
 
-bool SMAA_Dx12::CreateBufferResources(ID3D12Resource*)
+bool SMAA_Dx12::CreateBufferResources(ID3D12Resource* sourceTexture)
 {
-    return false;
+    if (!_init)
+    {
+        return false;
+    }
+
+    if (sourceTexture == nullptr)
+    {
+        LOG_WARN("[{}] CreateBufferResources called with null source texture", _name);
+        _buffersReady = false;
+        _processedResource = nullptr;
+        _inputResource = nullptr;
+        return false;
+    }
+
+    const D3D12_RESOURCE_DESC desc = sourceTexture->GetDesc();
+
+    const bool dimensionsChanged = (_cachedInputDesc.Width != desc.Width) ||
+                                   (_cachedInputDesc.Height != desc.Height) ||
+                                   (_cachedInputDesc.Format != desc.Format) ||
+                                   (_cachedInputDesc.DepthOrArraySize != desc.DepthOrArraySize);
+
+    if (!_buffersReady || dimensionsChanged)
+    {
+        LOG_INFO("[{}] Updating SMAA DX12 buffers to {}x{} (format={})", _name, desc.Width, desc.Height, static_cast<int>(desc.Format));
+
+        _edgeBuffer.Reset();
+        _blendBuffer.Reset();
+        _srvHeap.Reset();
+        _uavHeap.Reset();
+        ResetHandles(_inputColorSrv);
+        ResetHandles(_edgeBufferUav);
+        ResetHandles(_blendBufferUav);
+        ResetHandles(_processedColorSrv);
+
+        _cachedInputDesc = desc;
+        _buffersReady = true;
+    }
+
+    _inputResource = sourceTexture;
+    _processedResource = sourceTexture;
+    _currentInputState = D3D12_RESOURCE_STATE_COMMON;
+
+    return true;
 }
 
-bool SMAA_Dx12::Dispatch(ID3D12GraphicsCommandList*, ID3D12Resource*)
+bool SMAA_Dx12::Dispatch(ID3D12GraphicsCommandList* commandList, ID3D12Resource* sourceTexture)
 {
-    return false;
+    if (!_init)
+    {
+        return false;
+    }
+
+    if (commandList == nullptr)
+    {
+        LOG_WARN("[{}] Dispatch called with null command list", _name);
+        return false;
+    }
+
+    if (sourceTexture == nullptr)
+    {
+        LOG_WARN("[{}] Dispatch called with null source texture", _name);
+        return false;
+    }
+
+    if (!_buffersReady || sourceTexture != _inputResource)
+    {
+        if (!CreateBufferResources(sourceTexture))
+        {
+            return false;
+        }
+    }
+
+    if (_currentInputState != D3D12_RESOURCE_STATE_UNORDERED_ACCESS)
+    {
+        D3D12_RESOURCE_BARRIER barrier = {};
+        barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+        barrier.Transition.pResource = sourceTexture;
+        barrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+        barrier.Transition.StateBefore = _currentInputState;
+        barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
+        commandList->ResourceBarrier(1, &barrier);
+        _currentInputState = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
+    }
+
+    D3D12_RESOURCE_BARRIER uavBarrier = {};
+    uavBarrier.Type = D3D12_RESOURCE_BARRIER_TYPE_UAV;
+    uavBarrier.UAV.pResource = sourceTexture;
+    commandList->ResourceBarrier(1, &uavBarrier);
+
+    if (_currentInputState != D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE)
+    {
+        D3D12_RESOURCE_BARRIER barrier = {};
+        barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+        barrier.Transition.pResource = sourceTexture;
+        barrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+        barrier.Transition.StateBefore = _currentInputState;
+        barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
+        commandList->ResourceBarrier(1, &barrier);
+        _currentInputState = D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
+    }
+
+    _processedResource = sourceTexture;
+
+    return true;
 }
 

--- a/OptiScaler/shaders/smaa/SMAA_Dx12.h
+++ b/OptiScaler/shaders/smaa/SMAA_Dx12.h
@@ -1,7 +1,18 @@
 #pragma once
 
+#include <array>
 #include <string>
+
 #include <d3d12.h>
+#include <wrl/client.h>
+
+struct ID3D12DescriptorHeap;
+
+struct SMAAResourceHandles
+{
+    D3D12_CPU_DESCRIPTOR_HANDLE cpu = { 0 };
+    D3D12_GPU_DESCRIPTOR_HANDLE gpu = { 0 };
+};
 
 class SMAA_Dx12
 {
@@ -13,11 +24,29 @@ class SMAA_Dx12
     bool CreateBufferResources(ID3D12Resource* sourceTexture);
     bool Dispatch(ID3D12GraphicsCommandList* commandList, ID3D12Resource* sourceTexture);
 
-    ID3D12Resource* ProcessedResource() const { return nullptr; }
+    ID3D12Resource* ProcessedResource() const { return _processedResource; }
 
   private:
     std::string _name;
     ID3D12Device* _device = nullptr;
     bool _init = false;
+    bool _buffersReady = false;
+
+    SMAAResourceHandles _inputColorSrv;
+    SMAAResourceHandles _edgeBufferUav;
+    SMAAResourceHandles _blendBufferUav;
+    SMAAResourceHandles _processedColorSrv;
+
+    Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> _srvHeap;
+    Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> _uavHeap;
+
+    Microsoft::WRL::ComPtr<ID3D12Resource> _edgeBuffer;
+    Microsoft::WRL::ComPtr<ID3D12Resource> _blendBuffer;
+
+    ID3D12Resource* _processedResource = nullptr;
+    ID3D12Resource* _inputResource = nullptr;
+
+    D3D12_RESOURCE_DESC _cachedInputDesc = {};
+    D3D12_RESOURCE_STATES _currentInputState = D3D12_RESOURCE_STATE_COMMON;
 };
 


### PR DESCRIPTION
## Summary
- add resource handle members and processed resource tracking to the SMAA DirectX 12 wrapper
- implement placeholder buffer preparation logic that resets descriptors when the input changes
- add minimal dispatch flow that performs simple resource barriers and exposes the input as the processed output

## Testing
- not run (reason: no automated DirectX 12 validation available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cd8bc8d6948322bcccf7ac5e480a0a