### PR TITLE
Handle CMAA2 R11G11B10 untyped UAV stores

### DIFF
--- a/OptiScaler/shaders/smaa/CMAA project/CMAA2/CMAA2.hlsl
+++ b/OptiScaler/shaders/smaa/CMAA project/CMAA2/CMAA2.hlsl
@@ -399,6 +399,11 @@ uint FLOAT4_to_B8G8R8A8_UNORM( lpfloat4 unpackedInput )
             ( uint( saturate( unpackedInput.x ) * 255 + 0.5 ) << 16 ) |
             ( uint( saturate( unpackedInput.w ) * 255 + 0.5 ) << 24 ) );
 }
+
+uint FLOAT3_to_R11G11B10_FLOAT( lpfloat3 unpackedInput )
+{
+    return Pack_R11G11B10_FLOAT( unpackedInput );
+}
 //
 // This handles various permutations for various formats with no/partial/full typed UAV store support
 void FinalUAVStore( uint2 pixelPos, lpfloat3 color )
@@ -416,6 +421,8 @@ void FinalUAVStore( uint2 pixelPos, lpfloat3 color )
         g_inoutColorWriteonly[ pixelPos ] = FLOAT4_to_R10G10B10A2_UNORM( lpfloat4( color, 0 ) );
     #elif CMAA2_UAV_STORE_UNTYPED_FORMAT == 3   // B8G8R8A8_UNORM (or B8G8R8A8_UNORM_SRGB with CMAA2_UAV_STORE_CONVERT_TO_SRGB)
         g_inoutColorWriteonly[ pixelPos ] = FLOAT4_to_B8G8R8A8_UNORM( lpfloat4( color, 0 ) );
+    #elif CMAA2_UAV_STORE_UNTYPED_FORMAT == 4   // R11G11B10_FLOAT without typed UAV store support
+        g_inoutColorWriteonly[ pixelPos ] = FLOAT3_to_R11G11B10_FLOAT( color );
     #else
         #error CMAA color packing format not defined - add it here!
     #endif

--- a/OptiScaler/shaders/smaa/SMAA_Dx12.cpp
+++ b/OptiScaler/shaders/smaa/SMAA_Dx12.cpp
@@ -682,6 +682,10 @@ bool SMAA_Dx12::UpdateInputDescriptors(ID3D12Resource* sourceTexture, const D3D1
         {
             _shaderConfig.untypedStoreMode = 3;
         }
+        else if (stripped == DXGI_FORMAT_R11G11B10_FLOAT)
+        {
+            _shaderConfig.untypedStoreMode = 4;
+        }
         else
         {
             LOG_ERROR("[{}] Unsupported CMAA2 format for untyped UAV store ({})", _name, static_cast<int>(stripped));


### PR DESCRIPTION
## Summary
- allow SMAA_Dx12 to select an untyped UAV store mode for R11G11B10_FLOAT inputs when typed stores are unavailable
- add shader-side packing for the new untyped store mode so R11G11B10 data can be emitted through the R32_UINT UAV

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ceb44394408322b92bac6aada95d7c