### PR TITLE
Embed CMAA2 shader source for DX12

### DIFF
--- a/OptiScaler/shaders/smaa/SMAA_Dx12.h
+++ b/OptiScaler/shaders/smaa/SMAA_Dx12.h
@@ -86,6 +86,7 @@ class SMAA_Dx12
     };
 
     ShaderConfig _shaderConfig = {};
+    ShaderConfig _compiledConfig = {};
     D3D12_SHADER_RESOURCE_VIEW_DESC _colorSrvDesc = {};
     D3D12_UNORDERED_ACCESS_VIEW_DESC _colorUavDesc = {};
 };

--- a/OptiScaler/shaders/smaa/precompile/CMAA2_ShaderSource.h
+++ b/OptiScaler/shaders/smaa/precompile/CMAA2_ShaderSource.h
@@ -1,3 +1,6 @@
+#pragma once
+
+inline constexpr const char g_cmaa2ShaderSource[] = R"CMAA2(
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2018, Intel Corporation
 //
@@ -1477,3 +1480,5 @@ void DebugDrawEdgesCS( uint2 dispatchThreadID : SV_DispatchThreadID )
 #endif // #ifndef __cplusplus
 
 #endif // #ifndef __CMAA2_HLSL__
+
+)CMAA2";


### PR DESCRIPTION
## Summary
- embed the CMAA2.hlsl source into the binary so DX12 can compile it without shipping loose files
- allow SMAA_Dx12 to fall back on the embedded shader while still honoring on-disk overrides when present
- cache the shader configuration that produced the current pipelines to avoid redundant recompiles

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ceb44394408322b92bac6aada95d7c