### PR TITLE
Fix SMAA DX12 untyped UAV resource format

### DIFF
--- a/OptiScaler/shaders/smaa/SMAA_Dx12.h
+++ b/OptiScaler/shaders/smaa/SMAA_Dx12.h
@@ -32,7 +32,7 @@ class SMAA_Dx12
     bool EnsureDescriptorHeaps();
     bool EnsureIntermediateResources(const D3D12_RESOURCE_DESC& inputDesc);
     bool UpdateInputDescriptors(ID3D12Resource* sourceTexture, const D3D12_RESOURCE_DESC& inputDesc);
-    bool EnsureOutputResource(const D3D12_RESOURCE_DESC& inputDesc, DXGI_FORMAT uavFormat);
+    bool EnsureOutputResource(const D3D12_RESOURCE_DESC& inputDesc, DXGI_FORMAT resourceFormat);
 
     SMAAResourceHandles DescriptorFromIndex(const Microsoft::WRL::ComPtr<ID3D12DescriptorHeap>& heap, UINT index) const;
 


### PR DESCRIPTION
## Summary
- add helper to resolve the appropriate color resource format when CMAA2 falls back to untyped UAV stores
- keep the SMAA intermediate render target in its original/typeless color format while binding an R32_UINT UAV view for shader writes
- update the DX12 output resource allocation path to respect the color format so downstream consumers like DLSS see the expected texture description

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cef13ab4348322a248ba488138b456