### PR TITLE
Fix CMAA2 alias heap max macro usage

### DIFF
--- a/OptiScaler/shaders/smaa/SMAA_Dx12.cpp
+++ b/OptiScaler/shaders/smaa/SMAA_Dx12.cpp
@@ -878,8 +878,8 @@ bool SMAA_Dx12::EnsureOutputResource(const D3D12_RESOURCE_DESC& inputDesc, DXGI_
     auto computeInfo = _device->GetResourceAllocationInfo(0, 1, &computeDesc);
     auto colorInfo = _device->GetResourceAllocationInfo(0, 1, &colorDesc);
 
-    UINT64 heapSize = std::max(computeInfo.SizeInBytes, colorInfo.SizeInBytes);
-    UINT64 heapAlignment = std::max(computeInfo.Alignment, colorInfo.Alignment);
+    UINT64 heapSize = (std::max)(computeInfo.SizeInBytes, colorInfo.SizeInBytes);
+    UINT64 heapAlignment = (std::max)(computeInfo.Alignment, colorInfo.Alignment);
 
     D3D12_HEAP_DESC heapDesc = {};
     heapDesc.Properties.Type = D3D12_HEAP_TYPE_DEFAULT;


### PR DESCRIPTION
## Summary
- avoid interference from the Windows max macro when computing the CMAA2 alias heap size and alignment

## Testing
- attempted `msbuild OptiScaler.sln /t:OptiScaler /p:Configuration=Release` (fails: msbuild not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf9a02f894832284826e832632d15c